### PR TITLE
Mixed Commands update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # configuration file
 config.py
 
+# ide folder
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/99-robotarm.rules
+++ b/99-robotarm.rules
@@ -1,0 +1,1 @@
+DRIVER=="robotic_arm", MODE="0777", SYMLINK +="robot_arm%n"

--- a/bot.py
+++ b/bot.py
@@ -3,8 +3,12 @@ import math
 import os
 import re
 import fnmatch
+from os.path import split
+
 from twitchio.ext import commands, routines
 from arm_control import Arm
+from chat_log import ChatLog
+from enum import Enum
 
 # Arm Device Names
 BASE = "basemotor"
@@ -21,7 +25,6 @@ STOP = "0"
 CLOCKWISE = "1"
 COUNTER_CLOCKWISE = "2"
 
-# Directional Mapping
 UP = CLOCKWISE
 DOWN = COUNTER_CLOCKWISE
 LEFT = COUNTER_CLOCKWISE
@@ -32,6 +35,7 @@ CLOSE = CLOCKWISE
 
 # Twitch bot
 class Bot(commands.Bot):
+    chat_logger = ChatLog()
     def __init__(self):
         super().__init__(
             token=os.environ['TMI_TOKEN'],
@@ -49,93 +53,165 @@ class Bot(commands.Bot):
         # For now we just want to ignore them...
         if message.echo:
             return
-
         # Print the contents of our message to console...
-        print(message.content)
-
+        print(f'{message.author.name}: {message.content}')
+        # Lowercase the messages, so commands can be mixed.
+        message.content = message.content.lower()
         # Since we have commands and are overriding the default `event_message`
         # We must let the bot know we want to handle and invoke our commands...
         await self.handle_commands(message)
 
+    async def split_arg(self, arg):
+        if len(arg) < 3:
+            return
+        arm_selected = None
+        motor_selected = None
+        direction_selected = None
+        for i, char in enumerate(arg):
+            match i:
+                case 0:
+                    arm_selected = self.select_arm(char)
+                    break
+                case 1:
+                    motor_selected = self.select_motor(char)
+                    break
+                case 2:
+                    direction_selected = self.select_direction(char)
+                    break
+        time_selected = fod(arg[3:], 1.0)
+        if (arm_selected is not None
+                and motor_selected is not None
+                and direction_selected is not None
+                and time_selected is not None):
+            await write_motor(arm_selected, motor_selected, direction_selected, time_selected)
+
+    @staticmethod
+    def select_arm(value):
+        response = None
+        match value:
+            case "l":
+                response = LEFTARM
+            case "r":
+                response = RIGHTARM
+        return response
+
+    @staticmethod
+    def select_motor(value):
+        response = None
+        match value:
+            case "g":
+                response = GRIP
+            case "b":
+                response = BASE
+            case "w":
+                response = WRIST
+            case "e":
+                response = ELBOW
+            case "s":
+                response = SHOULDER
+        return response
+
+    @staticmethod
+    def select_direction(value):
+        response = None
+        match value:
+            case "u":
+                response = CLOCKWISE
+            case "d":
+                response = COUNTER_CLOCKWISE
+            case "l":
+                response = COUNTER_CLOCKWISE
+            case "r":
+                response = CLOCKWISE
+            case "o":
+                response = COUNTER_CLOCKWISE
+            case "c":
+                response = CLOCKWISE
+        return response
+    @commands.command(name='chain', aliases=['c', '!'])
+    async def chain(self, ctx:commands.Context):
+        for arg in ctx.args:
+            await self.split_arg(arg)
+
     @commands.command(name='leftgripopen', aliases=['lgo'])
     async def arm_l_gopen(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, GRIP, OPEN, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, GRIP, OPEN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftgripclose', aliases=['lgc'])
     async def arm_l_gclose(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, GRIP, CLOSE, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, GRIP, CLOSE, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftbaseleft', aliases=['lbl'])
     async def arm_l_bleft(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, BASE, LEFT, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, BASE, LEFT, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftbaseright', aliases=['lbr'])
     async def arm_l_bright(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, BASE, RIGHT, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, BASE, RIGHT, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftwristup', aliases=['lwu'])
     async def arm_l_wup(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftwristdown', aliases=['lwd'])
     async def arm_l_wdown(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftelbowup', aliases=['leu'])
     async def arm_l_eup(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftelbowdown', aliases=['led'])
     async def arm_l_edown(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, WRIST, UP, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, WRIST, UP, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftshoulderup', aliases=['lsu'])
     async def arm_l_sup(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, SHOULDER, UP, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, SHOULDER, UP, fod(ctx.message.content, 1.0))
 
     @commands.command(name='leftshoulderdown', aliases=['lsd'])
     async def arm_l_sdown(self, ctx: commands.Context):
-        await write_motor(ctx, LEFTARM, SHOULDER, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, SHOULDER, DOWN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightgripopen', aliases=['rgo'])
     async def arm_r_gopen(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, GRIP, OPEN, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, GRIP, OPEN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightgripclose', aliases=['rgc'])
     async def arm_r_gclose(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, GRIP, CLOSE, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, GRIP, CLOSE, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightbaseleft', aliases=['rbl'])
     async def arm_r_bleft(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, BASE, LEFT, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, BASE, LEFT, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightbaseright', aliases=['rbr'])
     async def arm_r_bright(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, BASE, RIGHT, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, BASE, RIGHT, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightwristup', aliases=['rwu'])
     async def arm_r_wup(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightwristdown', aliases=['rwd'])
     async def arm_r_wdown(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightelbowup', aliases=['reu'])
     async def arm_r_eup(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightelbowdown', aliases=['red'])
     async def arm_r_edown(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, WRIST, UP, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, WRIST, UP, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightshoulderup', aliases=['rsu'])
     async def arm_r_sup(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, SHOULDER, UP, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, SHOULDER, UP, fod(ctx.message.content, 1.0))
 
     @commands.command(name='rightshoulderdown', aliases=['rsd'])
     async def arm_r_sdown(self, ctx: commands.Context):
-        await write_motor(ctx, RIGHTARM, SHOULDER, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, SHOULDER, DOWN, fod(ctx.message.content, 1.0))
 
     @commands.command(name='help', aliases=['h', 'cmd', 'command', 'commands', 'man', 'manual'])
     async def help(self, ctx: commands.Context):
@@ -164,21 +240,17 @@ class Bot(commands.Bot):
 
 
 # Write to the arm device
-async def write_motor(ctx: commands.Context, device, motor, action, time):
+async def write_motor(device, motor, action, time):
     if math.isnan(time):
         time = 1.0
     if time < 0.1:
         time = 0.1
     if arm is not None:
         arm.drive(motor, action, time, device)
-        while len(arm.messages) > 0:
-            message = arm.messages.pop(0)
-            await ctx.send(message)
 
 # Float or Default
 # Find a number, or return the default
 def fod(string, default):
-    print("Finding numbers in: " + string)
     if any(str.isdigit(c) for c in string):
         numbers = re.findall(r'\d+[.|,]\d+|[.|,]\d|\d\d|\d', string)
         return float(numbers[0])

--- a/bot.py
+++ b/bot.py
@@ -13,8 +13,8 @@ from enum import Enum
 # Arm Device Names
 BASE = "basemotor"
 GRIP = "gripmotor"
-WRIST = "motor2"
-ELBOW = "motor3"
+ELBOW = "motor2"
+WRIST = "motor3"
 SHOULDER = "motor4"
 LIGHT = "led"
 LEFTARM = "l"
@@ -63,7 +63,7 @@ class Bot(commands.Bot):
 
     async def split_arg(self, arg):
         if len(arg) < 3:
-            return
+            return False
         arm_selected = None
         motor_selected = None
         direction_selected = None
@@ -71,19 +71,18 @@ class Bot(commands.Bot):
             match i:
                 case 0:
                     arm_selected = self.select_arm(char)
-                    break
                 case 1:
                     motor_selected = self.select_motor(char)
-                    break
                 case 2:
                     direction_selected = self.select_direction(char)
-                    break
         time_selected = fod(arg[3:], 1.0)
         if (arm_selected is not None
                 and motor_selected is not None
                 and direction_selected is not None
                 and time_selected is not None):
             await write_motor(arm_selected, motor_selected, direction_selected, time_selected)
+            return True
+        return False
 
     @staticmethod
     def select_arm(value):
@@ -130,88 +129,114 @@ class Bot(commands.Bot):
         return response
     @commands.command(name='chain', aliases=['c', '!'])
     async def chain(self, ctx:commands.Context):
-        for arg in ctx.args:
-            await self.split_arg(arg)
+        args = ""
+        for arg in ctx.message.content.split():
+            if len(arg) < 3:
+                continue
+            if await self.split_arg(arg):
+                args += " " + arg
+        if len(args) > 1:
+            self.chat_logger.msg(f'{ctx.author.name}:{args}')
 
     @commands.command(name='leftgripopen', aliases=['lgo'])
     async def arm_l_gopen(self, ctx: commands.Context):
         await write_motor(LEFTARM, GRIP, OPEN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lgo')
 
     @commands.command(name='leftgripclose', aliases=['lgc'])
     async def arm_l_gclose(self, ctx: commands.Context):
         await write_motor(LEFTARM, GRIP, CLOSE, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lgc')
 
     @commands.command(name='leftbaseleft', aliases=['lbl'])
     async def arm_l_bleft(self, ctx: commands.Context):
         await write_motor(LEFTARM, BASE, LEFT, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lbl')
 
     @commands.command(name='leftbaseright', aliases=['lbr'])
     async def arm_l_bright(self, ctx: commands.Context):
         await write_motor(LEFTARM, BASE, RIGHT, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lbr')
 
     @commands.command(name='leftwristup', aliases=['lwu'])
     async def arm_l_wup(self, ctx: commands.Context):
-        await write_motor(LEFTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, WRIST, UP, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lwu')
 
     @commands.command(name='leftwristdown', aliases=['lwd'])
     async def arm_l_wdown(self, ctx: commands.Context):
-        await write_motor(LEFTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lwd')
 
     @commands.command(name='leftelbowup', aliases=['leu'])
     async def arm_l_eup(self, ctx: commands.Context):
-        await write_motor(LEFTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:leu')
 
     @commands.command(name='leftelbowdown', aliases=['led'])
     async def arm_l_edown(self, ctx: commands.Context):
-        await write_motor(LEFTARM, WRIST, UP, fod(ctx.message.content, 1.0))
+        await write_motor(LEFTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:led')
 
     @commands.command(name='leftshoulderup', aliases=['lsu'])
     async def arm_l_sup(self, ctx: commands.Context):
         await write_motor(LEFTARM, SHOULDER, UP, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lsu')
 
     @commands.command(name='leftshoulderdown', aliases=['lsd'])
     async def arm_l_sdown(self, ctx: commands.Context):
         await write_motor(LEFTARM, SHOULDER, DOWN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:lsd')
 
     @commands.command(name='rightgripopen', aliases=['rgo'])
     async def arm_r_gopen(self, ctx: commands.Context):
         await write_motor(RIGHTARM, GRIP, OPEN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rgo')
 
     @commands.command(name='rightgripclose', aliases=['rgc'])
     async def arm_r_gclose(self, ctx: commands.Context):
         await write_motor(RIGHTARM, GRIP, CLOSE, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rgc')
 
     @commands.command(name='rightbaseleft', aliases=['rbl'])
     async def arm_r_bleft(self, ctx: commands.Context):
         await write_motor(RIGHTARM, BASE, LEFT, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rbl')
 
     @commands.command(name='rightbaseright', aliases=['rbr'])
     async def arm_r_bright(self, ctx: commands.Context):
         await write_motor(RIGHTARM, BASE, RIGHT, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rbr')
 
     @commands.command(name='rightwristup', aliases=['rwu'])
     async def arm_r_wup(self, ctx: commands.Context):
-        await write_motor(RIGHTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, WRIST, UP, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rwu')
 
     @commands.command(name='rightwristdown', aliases=['rwd'])
     async def arm_r_wdown(self, ctx: commands.Context):
-        await write_motor(RIGHTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rwd')
 
     @commands.command(name='rightelbowup', aliases=['reu'])
     async def arm_r_eup(self, ctx: commands.Context):
-        await write_motor(RIGHTARM, WRIST, DOWN, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, ELBOW, UP, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:reu')
 
     @commands.command(name='rightelbowdown', aliases=['red'])
     async def arm_r_edown(self, ctx: commands.Context):
-        await write_motor(RIGHTARM, WRIST, UP, fod(ctx.message.content, 1.0))
+        await write_motor(RIGHTARM, ELBOW, DOWN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:red')
 
     @commands.command(name='rightshoulderup', aliases=['rsu'])
     async def arm_r_sup(self, ctx: commands.Context):
         await write_motor(RIGHTARM, SHOULDER, UP, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rsu')
 
     @commands.command(name='rightshoulderdown', aliases=['rsd'])
     async def arm_r_sdown(self, ctx: commands.Context):
         await write_motor(RIGHTARM, SHOULDER, DOWN, fod(ctx.message.content, 1.0))
+        self.chat_logger.msg(f'{ctx.author.name}:rsd')
 
     @commands.command(name='help', aliases=['h', 'cmd', 'command', 'commands', 'man', 'manual'])
     async def help(self, ctx: commands.Context):

--- a/chat_log.py
+++ b/chat_log.py
@@ -1,0 +1,11 @@
+
+class ChatLog:
+    filename = "chat_log.txt"
+    def msg(self, message):
+        with open(self.filename, "a") as f:
+            f.write(message + "\n")
+            f.close()
+
+    def err(self, source, message):
+        print(f'{source}: {message}')
+        self.write_line(f'{source}: {message}')


### PR DESCRIPTION
# Feature #17 : Case insensitive input
Commands are now case insensitive

# New feature: Chat log
Commands, and errors are printed into a log file that can be fed into the display.

# Feature #13: Mix commands
Commands can be mixed together to move multiple joints at once.

## Command Structure
All commands are prefixed by either
- A single exclamation mark '!rgc 3'
- Or two exclamation marks and a space '!! rgc3'

This denotes a quick command from a chained command. 
- A quick command operates a single motor
- A chained command can control multiple motors at once.

Each command contains at least 3 letters, and optionally a number.

### Arm selection: First command letter
Currently, the two choices are left 'l' and right 'r'.
| Note: directions are relative to the robot's own perspective. |

### Joint selection: Second command letter
This selects the motor on the arm
- 'g': Grip
- 'w': Wrist
- 'e': Elbow
- 's': Shoulder
- 'b': Base

### Direction selection: Third command letter
This picks the direction the joint will move. This is handled differently between quick and chained commands. 
Chained command directions could accept any of these options, while quick commands are more absolutely defined.

- 'u': Up
- 'd': Down
- 'l': Left
- 'r': Right
- 'o': Open
- 'c': Close

### Duration selection: Trailing number (Optional)
Durations are given in seconds, and can have a decimal value. The valid range is between 0.1 and 4. If this is unset, then the default is 1 second.

- On a quick command, there should be a space between the number and your command. '!lbl 4.0'
- In chained commands, there should be no space between the number and the command. '!! lbl4.0 rbr2'


# Quick Commands

Left arm:
Grip: !lgo, !lgc
Wrist: !lwu, !lwd
Elbow: !leu, !led
Shoulder: !lsu, !lsd
Base: !lbr, !lbl

Right arm: 
Grip: !rgo, !rgc
Wrist: !rwu, !rwd
Elbow: !reu, !red
Shoulder: !rsu, !rsd
Base: !rbr, !rbl